### PR TITLE
fix typo: kedav1aplha1 => kedav1alpha1

### DIFF
--- a/pkg/reconciler/awssqs/awssqs.go
+++ b/pkg/reconciler/awssqs/awssqs.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	kedav1aplha1 "github.com/kedacore/keda/api/v1alpha1"
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -54,7 +54,7 @@ func GenerateScaleTargetName(ctx context.Context, kubeClient kubernetes.Interfac
 	return "", apierrors.NewNotFound(schema.GroupResource{}, "")
 }
 
-func GenerateScaleTriggers(src *awssqsv1alpha1.AwsSqsSource) ([]kedav1aplha1.ScaleTriggers, error) {
+func GenerateScaleTriggers(src *awssqsv1alpha1.AwsSqsSource) ([]kedav1alpha1.ScaleTriggers, error) {
 	queueLength, err := keda.GetInt32ValueFromMap(src.Annotations, keda.KedaAutoscalingAwsSqsQueueLength, defaultAwsSqsQueueLength)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func GenerateScaleTriggers(src *awssqsv1alpha1.AwsSqsSource) ([]kedav1aplha1.Sca
 		"awsRegion":   awsRegion,
 	}
 
-	return []kedav1aplha1.ScaleTriggers{
+	return []kedav1alpha1.ScaleTriggers{
 		{
 			Type:     "aws-sqs-queue",
 			Metadata: triggerMetadata,

--- a/pkg/reconciler/kafka/kafka.go
+++ b/pkg/reconciler/kafka/kafka.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	kedav1aplha1 "github.com/kedacore/keda/api/v1alpha1"
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 	kafkav1beta1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1beta1"
 	eventingutils "knative.dev/eventing/pkg/utils"
 
@@ -36,8 +36,8 @@ func GenerateScaleTargetName(src *kafkav1beta1.KafkaSource) string {
 	return eventingutils.GenerateFixedName(src, fmt.Sprintf("kafkasource-%s", src.Name))
 }
 
-func GenerateScaleTriggers(src *kafkav1beta1.KafkaSource) ([]kedav1aplha1.ScaleTriggers, error) {
-	triggers := []kedav1aplha1.ScaleTriggers{}
+func GenerateScaleTriggers(src *kafkav1beta1.KafkaSource) ([]kedav1alpha1.ScaleTriggers, error) {
+	triggers := []kedav1alpha1.ScaleTriggers{}
 	bootstrapServers := strings.Join(src.Spec.BootstrapServers[:], ",")
 	consumerGroup := src.Spec.ConsumerGroup
 
@@ -54,7 +54,7 @@ func GenerateScaleTriggers(src *kafkav1beta1.KafkaSource) ([]kedav1aplha1.ScaleT
 			"lagThreshold":     strconv.Itoa(int(*lagThreshold)),
 		}
 
-		trigger := kedav1aplha1.ScaleTriggers{
+		trigger := kedav1alpha1.ScaleTriggers{
 			Type:     "kafka",
 			Metadata: triggerMetadata,
 		}

--- a/pkg/reconciler/keda/resources.go
+++ b/pkg/reconciler/keda/resources.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
-	kedav1aplha1 "github.com/kedacore/keda/api/v1alpha1"
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	awssqsv1alpha1 "knative.dev/eventing-contrib/awssqs/pkg/apis/sources/v1alpha1"
@@ -38,7 +38,7 @@ var (
 	KedaSchemeGroupVersion = schema.GroupVersion{Group: "keda.sh", Version: "v1alpha1"}
 )
 
-func GenerateScaledObject(obj metav1.Object, gvk schema.GroupVersionKind, scaleTargetName string, triggers []kedav1aplha1.ScaleTriggers) (*kedav1aplha1.ScaledObject, error) {
+func GenerateScaledObject(obj metav1.Object, gvk schema.GroupVersionKind, scaleTargetName string, triggers []kedav1alpha1.ScaleTriggers) (*kedav1alpha1.ScaledObject, error) {
 
 	cooldownPeriod, err := GetInt32ValueFromMap(obj.GetAnnotations(), KedaAutoscalingCooldownPeriodAnnotation, defaultCooldownPeriod)
 	if err != nil {
@@ -57,7 +57,7 @@ func GenerateScaledObject(obj metav1.Object, gvk schema.GroupVersionKind, scaleT
 		return nil, err
 	}
 
-	return &kedav1aplha1.ScaledObject{
+	return &kedav1alpha1.ScaledObject{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateScaledObjectName(obj),
 			Namespace: obj.GetNamespace(),
@@ -65,12 +65,12 @@ func GenerateScaledObject(obj metav1.Object, gvk schema.GroupVersionKind, scaleT
 				*metav1.NewControllerRef(obj, gvk),
 			},
 		},
-		Spec: kedav1aplha1.ScaledObjectSpec{
+		Spec: kedav1alpha1.ScaledObjectSpec{
 			PollingInterval: pollingInterval,
 			CooldownPeriod:  cooldownPeriod,
 			MinReplicaCount: minReplicaCount,
 			MaxReplicaCount: maxReplicaCount,
-			ScaleTargetRef: &kedav1aplha1.ScaleTarget{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{
 				Name: scaleTargetName,
 			},
 			Triggers: triggers,

--- a/pkg/reconciler/source/source.go
+++ b/pkg/reconciler/source/source.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	kedav1aplha1 "github.com/kedacore/keda/api/v1alpha1"
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 	kedaclientset "github.com/kedacore/keda/pkg/generated/clientset/versioned"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -150,7 +150,7 @@ func (r *Reconciler) reconcileAwsSqsSource(ctx context.Context, src *awssqsv1alp
 	return r.reconcileScaledObject(ctx, scaledObject, src)
 }
 
-func (r *Reconciler) reconcileScaledObject(ctx context.Context, expectedScaledObject *kedav1aplha1.ScaledObject, obj metav1.Object) error {
+func (r *Reconciler) reconcileScaledObject(ctx context.Context, expectedScaledObject *kedav1alpha1.ScaledObject, obj metav1.Object) error {
 	scaledObject, err := r.kedaClient.KedaV1alpha1().ScaledObjects(expectedScaledObject.Namespace).Get(ctx, expectedScaledObject.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		scaledObject, err = r.kedaClient.KedaV1alpha1().ScaledObjects(expectedScaledObject.Namespace).Create(ctx, expectedScaledObject, metav1.CreateOptions{})


### PR DESCRIPTION
No functional changes, just changing the typo for import/use from:
kedav1aplha1 -> kedav1alpha1
