### PR TITLE
plumb broker annotations through, add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ metadata:
 - `keda.autoscaling.knative.dev/awsSqsQueueLength` - only for AWS SQS Source, refers to the target value for ApproximateNumberOfMessages in the SQS Queue. Default: `5`
 - `keda.autoscaling.knative.dev/rabbitMQQueueLength` - only for AWS SQS Source, refers to the target value for number of messages in a RabbitMQ brokers trigger queue: `1`
 
-
-## Technical details & limitations
-This controller requires k8s.io client version >= 0.18, therefore it is using custom fork of [knative/pkg](https://github.com/zroubalik/pkg/tree/k8s18) and [knative/eventing](https://github.com/zroubalik/eventing/tree/k8s18).
-
 ## HOW TO
 
 ### Install KEDA v2

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently there is support for **Kafka Source** and **AWS SQS Source**. We also
 have experimental support for **RabbitMQ Broker**.
 
 ## Annotations
-User can enable and configure autoscaling on a particular Source or Broker by a set of annotations. 
+User can enable and configure autoscaling on a particular Source or Broker by a set of annotations.
 
 ```yaml
 metadata:
@@ -126,7 +126,7 @@ so-f87369e5-c320-4f44-b23a-8c535a523e3a   apps/v1.Deployment   kafkasource-kafka
 
 ## Example of RabbitMQ Broker autoscaled by KEDA
 
-1. Install Knative Serving and Eventing 
+1. Install Knative Serving and Eventing
 
 2. Install [RabbitMQ Broker](https://github.com/knative-sandbox/eventing-rabbitmq/tree/master/broker)
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/google/licenseclassifier v0.0.0-20200708223521-3d09a0ea2f39
 	github.com/kedacore/keda v1.5.1-0.20200914094616-3a99b77cc330
-	github.com/kelseyhightower/envconfig v1.4.0
 	go.uber.org/zap v1.15.0
 	k8s.io/api v0.18.8
 	k8s.io/apiextensions-apiserver v0.18.8

--- a/pkg/reconciler/keda/annotations.go
+++ b/pkg/reconciler/keda/annotations.go
@@ -44,4 +44,8 @@ const (
 
 	// KedaAutoscalingAwsSqsQueueLength is the annotation that refers to the target value for ApproximateNumberOfMessages in the SQS Queue
 	KedaAutoscalingAwsSqsQueueLength = KEDA + "/awsSqsQueueLength"
+
+	// KedaAutoscalingRabbitMQQueueLength is the annotation that refers to the target value for number of messages in a RabbitMQ brokers
+	// trigger queue.
+	KedaAutoscalingRabbitMQQueueLength = KEDA + "/rabbitMQQueueLength"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -164,7 +164,6 @@ github.com/kedacore/keda/pkg/generated/informers/externalversions/keda
 github.com/kedacore/keda/pkg/generated/informers/externalversions/keda/v1alpha1
 github.com/kedacore/keda/pkg/generated/listers/keda/v1alpha1
 # github.com/kelseyhightower/envconfig v1.4.0
-## explicit
 github.com/kelseyhightower/envconfig
 # github.com/konsorten/go-windows-terminal-sequences v1.0.3
 github.com/konsorten/go-windows-terminal-sequences


### PR DESCRIPTION
Previously the values for scaledobjects were hardcoded, now take the values from the broker annotations and handle lifecycle if annotations get modified or deleted.
Add documentation.