### PR TITLE
Use RunContext as Run is deprecated

### DIFF
--- a/pkg/reconciler/crd/reconciler.go
+++ b/pkg/reconciler/crd/reconciler.go
@@ -210,7 +210,7 @@ func (r *Reconciler) reconcileController(ctx context.Context, crd *v1.CustomReso
 	logging.FromContext(ctx).Infow("Starting Source Duck Controller", zap.String("GVR", gvr.String()), zap.String("GVK", gvk.String()))
 	go func(c *controller.Impl) {
 		if c != nil {
-			if err := c.Run(controller.DefaultThreadsPerController, sdctx.Done()); err != nil {
+			if err := c.RunContext(sdctx, controller.DefaultThreadsPerController); err != nil {
 				logging.FromContext(ctx).Errorw("Unable to start Source Duck Controller", zap.String("GVR", gvr.String()), zap.String("GVK", gvk.String()))
 			}
 		}


### PR DESCRIPTION
I'm removing this Deprecated method in `knative.dev/pkg` since it's been a few years