### PR TITLE
Fix unicode character problem

### DIFF
--- a/test/config/100-strimzi-cluster-operator-0.23.0.yaml
+++ b/test/config/100-strimzi-cluster-operator-0.23.0.yaml
@@ -11092,7 +11092,7 @@ spec:
               bootstrapServers:
                 type: string
                 description: Bootstrap servers to connect to. This should be given
-                  as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+                  as a comma separated list of _<hostname>_:_<port>_ pairs.
               tls:
                 type: object
                 properties:
@@ -12982,7 +12982,7 @@ spec:
               bootstrapServers:
                 type: string
                 description: Bootstrap servers to connect to. This should be given
-                  as a comma separated list of _<hostname>_:‍_<port>_ pairs.
+                  as a comma separated list of _<hostname>_:_<port>_ pairs.
               tls:
                 type: object
                 properties:


### PR DESCRIPTION
unicode control characters ['\u200d'] - as reported:
https://github.com/knative-sandbox/eventing-autoscaler-keda/runs/5470707518?check_suite_focus=true#step:7:19

The original file contained what is being reposted as invisible `:`.