### PR TITLE
update rabbitmq queue name to match eventing-rabbitmq

### DIFF
--- a/pkg/reconciler/trigger/resources/scaled_object.go
+++ b/pkg/reconciler/trigger/resources/scaled_object.go
@@ -75,9 +75,7 @@ func MakeDispatcherScaledObject(ctx context.Context, b *v1.Broker, t *v1.Trigger
 		queueLength = defaultQueueLength
 	}
 
-	// TODO(vaikas): https://github.com/knative-sandbox/eventing-rabbitmq/issues/61
-	// queueName := fmt.Sprintf("%s/%s", t.Namespace, t.Name)
-	queueName := fmt.Sprintf("%s-%s", t.Namespace, t.Name)
+	queueName := fmt.Sprintf("%s.%s.%s", t.Namespace, t.Name, b.GetUID())
 	deploymentName := fmt.Sprintf("%s-dispatcher", t.Name)
 	triggerAuthenticationName := fmt.Sprintf("%s-trigger-auth", t.Spec.Broker)
 


### PR DESCRIPTION
# Changes
- :bug: Fixes issue with eventing-rabbitmq where the queueName used in ScaledObject is outdated


/kind bug

**Release Note**

```release-note
- Fixed issue with eventing-rabbitmq with mismatched Queue name
```

